### PR TITLE
Add vacation mode feature

### DIFF
--- a/src/app/api/temperatureCron/route.ts
+++ b/src/app/api/temperatureCron/route.ts
@@ -25,6 +25,22 @@ function addDays(date: Date, days: number): Date {
   return result;
 }
 
+const SCHEDULE_WINDOW_MINUTES = 15;
+
+// Returns true if vacation mode should suppress the schedule.
+// Vacation ends once we are within SCHEDULE_WINDOW_MINUTES of pre-heating on the resume date,
+// so the first cron run that would trigger pre-heating is also the first run where vacation is off.
+function isVacationModeOn(vacationDate: string, userNow: Date, preHeatingTime: Date): boolean {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const todayStr = `${userNow.getFullYear()}-${pad(userNow.getMonth() + 1)}-${pad(userNow.getDate())}`;
+
+  if (todayStr < vacationDate) return true;   // before resume date
+  if (todayStr > vacationDate) return false;  // after resume date
+
+  // On the resume date: stay off until within SCHEDULE_WINDOW_MINUTES of pre-heating
+  return userNow.getTime() < preHeatingTime.getTime() - SCHEDULE_WINDOW_MINUTES * 60 * 1000;
+}
+
 function isWithinTimeRange(current: Date, target: Date, rangeMinutes: number): boolean {
   const diffMs = Math.abs(current.getTime() - target.getTime());
   return diffMs <= rangeMinutes * 60 * 1000;
@@ -125,6 +141,21 @@ export async function adjustTemperature(testMode?: TestMode): Promise<void> {
         const userTemperatureProfile = profile.userTemperatureProfiles;
         const userNow = new Date(now.toLocaleString("en-US", { timeZone: userTemperatureProfile.timezoneTZ }));
 
+        if (userTemperatureProfile.vacationModeUntil) {
+          const todaySleepCycle = createSleepCycle(userNow, userTemperatureProfile.bedTime, userTemperatureProfile.wakeupTime);
+          if (isVacationModeOn(userTemperatureProfile.vacationModeUntil, userNow, todaySleepCycle.preHeatingTime)) {
+            console.log(`Vacation mode active for user ${profile.users.email}. Resumes on ${userTemperatureProfile.vacationModeUntil}. Skipping.`);
+            if (!testMode?.enabled) {
+              const heatingStatus = await retryApiCall(() => getCurrentHeatingStatus(token));
+              if (heatingStatus.isHeating) {
+                await retryApiCall(() => turnOffSide(token, profile.users.eightUserId));
+                console.log(`Heating turned off for vacation mode for user ${profile.users.email}`);
+              }
+            }
+            continue;
+          }
+        }
+
         // Create the sleep cycle based on the user's bed time and wake-up time
         const sleepCycle = createSleepCycle(userNow, userTemperatureProfile.bedTime, userTemperatureProfile.wakeupTime);
 
@@ -155,11 +186,11 @@ export async function adjustTemperature(testMode?: TestMode): Promise<void> {
         console.log(`Final stage: ${adjustedCycle.finalStageTime.toISOString()}`);
         console.log(`Wake-up: ${adjustedCycle.wakeupTime.toISOString()}`);
 
-        const isNearPreHeating = isWithinTimeRange(userNow, adjustedCycle.preHeatingTime, 15);
-        const isNearBedTime = isWithinTimeRange(userNow, adjustedCycle.bedTime, 15);
-        const isNearMidStage = isWithinTimeRange(userNow, adjustedCycle.midStageTime, 15);
-        const isNearFinalStage = isWithinTimeRange(userNow, adjustedCycle.finalStageTime, 15);
-        const isNearWakeup = isWithinTimeRange(userNow, adjustedCycle.wakeupTime, 15);
+        const isNearPreHeating = isWithinTimeRange(userNow, adjustedCycle.preHeatingTime, SCHEDULE_WINDOW_MINUTES);
+        const isNearBedTime = isWithinTimeRange(userNow, adjustedCycle.bedTime, SCHEDULE_WINDOW_MINUTES);
+        const isNearMidStage = isWithinTimeRange(userNow, adjustedCycle.midStageTime, SCHEDULE_WINDOW_MINUTES);
+        const isNearFinalStage = isWithinTimeRange(userNow, adjustedCycle.finalStageTime, SCHEDULE_WINDOW_MINUTES);
+        const isNearWakeup = isWithinTimeRange(userNow, adjustedCycle.wakeupTime, SCHEDULE_WINDOW_MINUTES);
 
         // Determine current sleep stage
         let currentSleepStage = "outside sleep cycle";
@@ -211,7 +242,7 @@ export async function adjustTemperature(testMode?: TestMode): Promise<void> {
               console.log(`Heating level set to ${targetLevel} for user ${profile.users.email}`);
             }
           }
-        } else if (heatingStatus.isHeating && userNow > adjustedCycle.wakeupTime && !isWithinTimeRange(userNow, adjustedCycle.wakeupTime, 15)) {
+        } else if (heatingStatus.isHeating && userNow > adjustedCycle.wakeupTime && !isWithinTimeRange(userNow, adjustedCycle.wakeupTime, SCHEDULE_WINDOW_MINUTES)) {
           // Only turn off heating if it's more than 15 minutes past wake-up time
           if (testMode?.enabled) {
             console.log(`[TEST MODE] Would turn off heating for user ${profile.users.email}`);

--- a/src/components/temperatureProfileForm.tsx
+++ b/src/components/temperatureProfileForm.tsx
@@ -26,6 +26,8 @@ export const TemperatureProfileForm: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isExistingProfile, setIsExistingProfile] = useState(false);
   const [sleepDurationError, setSleepDurationError] = useState<string | null>(null);
+  const [vacationModeUntil, setVacationModeUntil] = useState<string | null>(null);
+  const [vacationDateInput, setVacationDateInput] = useState<string>("");
 
   const {
     register,
@@ -70,6 +72,14 @@ export const TemperatureProfileForm: React.FC = () => {
       setValue("timezone", { value: profile.timezoneTZ });
       setIsExistingProfile(true);
       setIsLoading(false);
+      if (profile.vacationModeUntil) {
+        const pad = (n: number) => String(n).padStart(2, "0");
+        const today = new Date();
+        const todayStr = `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(today.getDate())}`;
+        setVacationModeUntil(profile.vacationModeUntil >= todayStr ? profile.vacationModeUntil : null);
+      } else {
+        setVacationModeUntil(null);
+      }
     } else if (getUserTemperatureProfileQuery.isError) {
       console.error("Failed to fetch temperature profile. Using default values.", getUserTemperatureProfileQuery.error);
       setIsExistingProfile(false);
@@ -118,6 +128,28 @@ export const TemperatureProfileForm: React.FC = () => {
         console.error("Failed to update temperature profile:", error.message);
       },
     });
+
+  const setVacationModeMutation = apiR.user.setVacationMode.useMutation({
+    onSuccess: (_, variables) => {
+      setVacationModeUntil(variables.until);
+      setVacationDateInput("");
+      void getUserTemperatureProfileQuery.refetch();
+    },
+    onError: (error) => {
+      console.error("Failed to set vacation mode:", error.message);
+    },
+  });
+
+  const isVacationActive = !!vacationModeUntil;
+
+  const onEnableVacation = () => {
+    if (!vacationDateInput) return;
+    setVacationModeMutation.mutate({ until: vacationDateInput });
+  };
+
+  const onDisableVacation = () => {
+    setVacationModeMutation.mutate({ until: null });
+  };
 
   const deleteProfileMutation =
     apiR.user.deleteUserTemperatureProfile.useMutation({
@@ -304,6 +336,59 @@ export const TemperatureProfileForm: React.FC = () => {
           control={control}
           info={`Starts at ${sleepInfo.finalStageTime}`}
         />
+
+        {isExistingProfile && (
+          <div className={`rounded-md p-4 ${isVacationActive ? "bg-amber-50 border border-amber-300" : "bg-gray-50 border border-gray-200"}`}>
+            <h3 className="mb-2 text-sm font-semibold text-gray-800">Vacation Mode</h3>
+            {isVacationActive ? (
+              <div>
+                <p className="mb-3 text-sm text-amber-800">
+                  Active — schedule resumes on{" "}
+                  <strong>
+                    {new Date(vacationModeUntil! + "T00:00:00").toLocaleDateString(undefined, {
+                      weekday: "short", year: "numeric", month: "short", day: "numeric",
+                    })}
+                  </strong>
+                  . The bed will not turn on before then.
+                </p>
+                <Button
+                  type="button"
+                  onClick={onDisableVacation}
+                  disabled={setVacationModeMutation.isPending}
+                  className="rounded-md border border-transparent bg-amber-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
+                >
+                  {setVacationModeMutation.isPending ? "Saving..." : "Resume Schedule Now"}
+                </Button>
+              </div>
+            ) : (
+              <div>
+                <p className="mb-2 text-sm text-gray-600">
+                  Pause the schedule until a future date. The bed won&apos;t turn on until then.
+                </p>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="date"
+                    value={vacationDateInput}
+                    min={new Date().toISOString().split("T")[0]}
+                    onChange={(e) => setVacationDateInput(e.target.value)}
+                    className="block rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-800 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
+                  />
+                  <Button
+                    type="button"
+                    onClick={onEnableVacation}
+                    disabled={!vacationDateInput || setVacationModeMutation.isPending}
+                    className="rounded-md border border-transparent bg-gray-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 disabled:opacity-50"
+                  >
+                    {setVacationModeMutation.isPending ? "Saving..." : "Enable Vacation Mode"}
+                  </Button>
+                </div>
+              </div>
+            )}
+            {setVacationModeMutation.isError && (
+              <p className="mt-2 text-sm text-red-600">Error updating vacation mode. Please try again.</p>
+            )}
+          </div>
+        )}
 
         <div className="flex justify-between">
           <Button

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -273,6 +273,30 @@ export const userRouter = createTRPCRouter({
       }
     }),
 
+  setVacationMode: publicProcedure
+    .input(
+      z.object({
+        until: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable(), // YYYY-MM-DD or null to clear
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      try {
+        const decoded = await checkAuthCookie(ctx.headers);
+        await db
+          .update(userTemperatureProfile)
+          .set({ vacationModeUntil: input.until, updatedAt: new Date() })
+          .where(eq(userTemperatureProfile.email, decoded.email))
+          .execute();
+        return { success: true };
+      } catch (error) {
+        console.error("Error setting vacation mode:", error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "An unexpected error occurred while setting vacation mode.",
+        });
+      }
+    }),
+
   deleteUserTemperatureProfile: publicProcedure.mutation(async ({ ctx }) => {
     try {
       const decoded = await checkAuthCookie(ctx.headers);

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,5 +1,6 @@
 import { relations } from "drizzle-orm";
 import {
+  date,
   integer,
   pgTableCreator,
   text,
@@ -30,6 +31,7 @@ export const userTemperatureProfile = createTable("userTemperatureProfiles", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
   timezoneTZ: varchar("timezone", { length: 50 }).notNull(),
+  vacationModeUntil: date("vacationModeUntil"),
 });
 
 export const usersRelations = relations(users, ({ one }) => ({


### PR DESCRIPTION
Adds a vacation mode that pauses the heating schedule until a chosen
resume date. The cron job skips heating while vacation is active and
resumes within SCHEDULE_WINDOW_MINUTES of pre-heating time on the
resume date. Includes DB schema column, tRPC mutation, cron logic,
and UI card in the temperature profile form.